### PR TITLE
Metadata options for ICC Profile extraction

### DIFF
--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -201,7 +201,6 @@ public class ImageMetadataReader
     {
         metadataOptions = options;
         Metadata metadata = readMetadata(file);
-        metadataOptions.reset();
         return metadata;
     }
 
@@ -210,7 +209,6 @@ public class ImageMetadataReader
     {
         metadataOptions = options;
         Metadata metadata = readMetadata(inputStream);
-        metadataOptions.reset();
         return metadata;
     }
 
@@ -219,7 +217,6 @@ public class ImageMetadataReader
     {
         metadataOptions = options;
         Metadata metadata = readMetadata(inputStream, streamLength, fileType);
-        metadataOptions.reset();
         return metadata;
     }
 
@@ -228,7 +225,6 @@ public class ImageMetadataReader
     {
         metadataOptions = options;
         Metadata metadata = readMetadata(inputStream, streamLength);
-        metadataOptions.reset();
         return metadata;
     }
 

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -79,6 +79,8 @@ import java.util.Collection;
  */
 public class ImageMetadataReader
 {
+    public static MetadataOptions metadataOptions;
+
     /**
      * Reads metadata from an {@link InputStream}.
      *
@@ -191,6 +193,42 @@ public class ImageMetadataReader
             inputStream.close();
         }
         new FileMetadataReader().read(file, metadata);
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull final File file, @NotNull MetadataOptions options) throws  ImageProcessingException, IOException
+    {
+        metadataOptions = options;
+        Metadata metadata = readMetadata(file);
+        metadataOptions.reset();
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull final InputStream inputStream, @NotNull MetadataOptions options) throws ImageProcessingException, IOException
+    {
+        metadataOptions = options;
+        Metadata metadata = readMetadata(inputStream);
+        metadataOptions.reset();
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull final InputStream inputStream, final long streamLength, final FileType fileType, @NotNull MetadataOptions options) throws IOException, ImageProcessingException
+    {
+        metadataOptions = options;
+        Metadata metadata = readMetadata(inputStream, streamLength, fileType);
+        metadataOptions.reset();
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull final InputStream inputStream, final long streamLength, @NotNull MetadataOptions options) throws ImageProcessingException, IOException
+    {
+        metadataOptions = options;
+        Metadata metadata = readMetadata(inputStream, streamLength);
+        metadataOptions.reset();
         return metadata;
     }
 

--- a/Source/com/drew/imaging/MetadataOptions.java
+++ b/Source/com/drew/imaging/MetadataOptions.java
@@ -1,0 +1,22 @@
+package com.drew.imaging;
+
+/**
+ * @author Payton Garland
+ */
+public class MetadataOptions
+{
+    boolean extractIccProfile;
+
+    public MetadataOptions() {
+        this.extractIccProfile = false;
+    }
+
+    public void setExtractIccProfile(boolean option) {
+        this.extractIccProfile = option;
+    }
+
+    public void reset()
+    {
+        this.extractIccProfile = false;
+    }
+}

--- a/Source/com/drew/imaging/MetadataOptions.java
+++ b/Source/com/drew/imaging/MetadataOptions.java
@@ -1,22 +1,39 @@
 package com.drew.imaging;
 
+import com.drew.lang.annotations.NotNull;
+
 /**
  * @author Payton Garland
  */
 public class MetadataOptions
 {
-    boolean extractIccProfile;
+    private final boolean extractIccProfile;
 
-    public MetadataOptions() {
-        this.extractIccProfile = false;
+    public MetadataOptions(@NotNull final boolean extractIccProfile) {
+        this.extractIccProfile = extractIccProfile;
     }
 
-    public void setExtractIccProfile(boolean option) {
-        this.extractIccProfile = option;
+    public boolean shouldExtractIccProfile() {
+        return extractIccProfile;
     }
 
-    public void reset()
+    public static class MetadataOptionsBuilder
     {
-        this.extractIccProfile = false;
+        boolean extractIccProfile;
+
+        public MetadataOptionsBuilder() {
+
+        }
+
+        public MetadataOptionsBuilder setExtractIccProfile(@NotNull boolean option) {
+            this.extractIccProfile = option;
+            return this;
+        }
+
+        public MetadataOptions create() {
+            return new MetadataOptions(
+                extractIccProfile
+            );
+        }
     }
 }

--- a/Source/com/drew/metadata/icc/IccDirectory.java
+++ b/Source/com/drew/metadata/icc/IccDirectory.java
@@ -52,6 +52,9 @@ public class IccDirectory extends Directory
     public static final int TAG_PROFILE_CREATOR = 80;
     public static final int TAG_TAG_COUNT = 128;
 
+    // Full ICC Profile - Only available via MetadataOptions
+    public static final int TAG_ICC_PROFILE = 0x0200;
+
     // These tag values
 
     public static final int TAG_TAG_A2B0 = 0x41324230;
@@ -108,6 +111,8 @@ public class IccDirectory extends Directory
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
 
     static {
+        _tagNameMap.put(TAG_ICC_PROFILE, "ICC Profile");
+
         _tagNameMap.put(TAG_PROFILE_BYTE_COUNT, "Profile Size");
         _tagNameMap.put(TAG_CMM_TYPE, "CMM Type");
         _tagNameMap.put(TAG_PROFILE_VERSION, "Version");

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -20,6 +20,8 @@
  */
 package com.drew.metadata.icc;
 
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.MetadataOptions;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
@@ -31,6 +33,8 @@ import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataReader;
 
+import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collections;
 
@@ -102,6 +106,18 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
 
         if (parentDirectory != null)
             directory.setParent(parentDirectory);
+
+        if (ImageMetadataReader.metadataOptions.shouldExtractIccProfile()) {
+            try {
+                if (reader.getLength() == (int) reader.getLength()) {
+                    directory.setByteArray(IccDirectory.TAG_ICC_PROFILE, reader.getBytes(0, (int)reader.getLength()));
+                } else {
+                    directory.addError("Unable to extract ICC Profile: length does not fit in integer");
+                }
+            } catch (IOException e) {
+                directory.addError("Unable to extract ICC Profile: " + e.getMessage());
+            }
+        }
 
         try {
             int profileByteCount = reader.getInt32(IccDirectory.TAG_PROFILE_BYTE_COUNT);


### PR DESCRIPTION
Adds MetadataOptions object that can be modified and added as an argument to ImageMetadataReader methods.  Current functionality is specifying if the ICC Profile should be extracted and stored in the ICCDirectory.